### PR TITLE
Feat: Service collections

### DIFF
--- a/.changeset/metal-mails-play.md
+++ b/.changeset/metal-mails-play.md
@@ -1,0 +1,5 @@
+---
+"services-framework": minor
+---
+
+Added service collections

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -42,7 +42,9 @@ module.exports = {
 				'code': 85,
 				'ignoreUrls': true,
 				'ignoreStrings': true,
-				'tabWidth': 0
+				'tabWidth': 0,
+				'ignoreTemplateLiterals': true,
+				'ignoreRegExpLiterals': true
 			}
 		],
 		// No semi colon:

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,6 +37,14 @@ module.exports = {
 				'allowTemplateLiterals': true
 			}
 		],
+		'max-len': ['warn',
+			{
+				'code': 85,
+				'ignoreUrls': true,
+				'ignoreStrings': true,
+				'tabWidth': 0
+			}
+		],
 		// No semi colon:
 		'semi': [
 			'error', 'never'

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 
 
-> I'd be happy to recieve [#feedback](https://github.com/Refzlund/services-framework/labels/feedback) moving towards v2
+> I'd be happy to recieve [#feedback](https://github.com/Refzlund/services-framework/labels/feedback%20wanted) moving towards v2
 
 Services Framework, a powerful solution for creating modular, test-driven, and fully typed services for your projects. Say goodbye to messy code and hello to a clean and organized API that enhances developer experience and reusability.
 
 - 🤩 **Modular**: Granular and modular control of entities
-- 🧪 **Test-driven**: Write reliable and maintainable code
+- 🧪 **Better testing suites**: Write reliable and maintainable code with *unit testing* / *test-driven development*
 - 💫 **Typed**: TypeScript support for maximum safety and productivity
 
 <br><br>
@@ -105,16 +105,16 @@ export default <T extends ClassOf<any>>(opts: Options) => ({
 			table: opts.table,
 			...
 		},
-		services: {
+		services: [
 			get<T>
 			saveAll<T>
-		}
+		]
 	}
 
 	instance: {
-		services: {
+		services: [
 			save<T>
-		}
+		]
 	}
 
 }) satisfies Collection<T>

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ giving you more control of test suites.
 
 ```ts
 // ../entities/user/sign-up.ts
-import type { ClassConstructor, StaticServiceFunction } from 'services-framework'
+import type { ClassConstructor, StaticServiceFunction, ClassOf } from 'services-framework'
 import type { User } from '$entities/user'
 
 // Extending T sets the requirements for T.
-export default (<T extends User>(User: ClassConstructor<T>) => ({
+export default (<T extends ClassOf<User>>(User: ClassConstructor<T>) => ({
 
 	async signUp(details: Partial<T> & Authentication) {
 		const user = new User(...)
@@ -74,7 +74,7 @@ import type { ClassConstructor, InstanceServiceFunction } from 'services-framewo
 import type { User } from '$entities/user'
 
 // Extending T sets the requirements for T.
-export default (<T extends User>(User: ClassConstructor<T>, instance: T, locals: Record<any, any>) => ({
+export default (<T extends ClassOf<User>>(User: ClassConstructor<T>, instance: T, locals: Record<any, any>) => ({
 
 	async getCompanies() {
 		const companies = instance.companies || []
@@ -85,6 +85,39 @@ export default (<T extends User>(User: ClassConstructor<T>, instance: T, locals:
 	}
 
 })) satisfies InstanceServiceFunction
+```
+</details>
+
+<details><summary>databaseHandlers (<i>Service Collection</i>)</summary>
+
+```ts
+// ../services/collection.database-handlers.ts
+import ... from ...
+
+interface Options = {
+	collection: string
+}
+
+export default <T extends ClassOf<any>>(opts: Options) => ({
+
+	static: {
+		locals: {
+			collection: opts.collection,
+			...
+		},
+		services: {
+			get<T>
+			saveAll<T>
+		}
+	}
+
+	instance: {
+		services: {
+			save<T>
+		}
+	}
+
+}) satisfies Collection<T>
 ```
 </details>
 
@@ -100,7 +133,7 @@ export default function(opts: Options) {
 
 	// 👇 Do not run code between this function and the returned Record-object
 	// As the keys are fetched like this: `service(null, null)`
-	return (<T>(Service: ClassConstructor<T>, instance: T) => ({
+	return (<T extends ClassOf<any>>(Service: ClassConstructor<T>, instance: T, locals: Record<any, any>) => ({
 
 		async someFunction() {
 			...
@@ -155,7 +188,7 @@ export const userService = {
 
 	//*WIP
 	collections: [ 
-		databaseHandlers<User>({...options})
+		databaseHandlers<User>({ collection: 'users' })
 	] 
 } satisfies Service<User>
 ```

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ export default (<T extends ClassOf<User>>(User: ClassConstructor<T>, instance: T
 import ... from ...
 
 interface Options = {
-	collection: string
+	table: string
 }
 
 export default <T extends ClassOf<any>>(opts: Options) => ({
 
 	static: {
 		locals: {
-			collection: opts.collection,
+			table: opts.table,
 			...
 		},
 		services: {
@@ -159,6 +159,7 @@ import signUp from '$entities/user/sign-up'
 import logIn from '$entities/user/log-in'
 import getCompanies from '$entities/user/get-companies'
 import databaseHandlers from '$services/collection.database-handlers'
+import passwordHash from '$utils/password-hash.ts'
 
 export class User {
 	...
@@ -169,7 +170,7 @@ export const userService = {
 
 	static: {
 		locals: {
-			collection: 'users'
+			passwordEncryption: passwordHash
 		},
 		services: [
 			signUp<User>, 
@@ -188,7 +189,7 @@ export const userService = {
 
 	//*WIP
 	collections: [ 
-		databaseHandlers<User>({ collection: 'users' })
+		databaseHandlers<User>({ table: 'users' })
 	] 
 } satisfies Service<User>
 ```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"scripts": {
 		"lint": "eslint src/**",
 		"test": "vitest",
+		"precommit": "pnpm run lint && pnpm run test",
 		"build": "vite build",
 		"release": "pnpm run build && changeset publish"
 	},

--- a/src/create-service.ts
+++ b/src/create-service.ts
@@ -68,15 +68,23 @@ export function createServiceFramework<const S extends Service<any>>(
 	const Framework = class extends (<any>services.entity) {
 		constructor(...args: any) {
 			super(...args)
+
+			// TODO: Make into proxy https://github.com/Refzlund/services-framework/issues/11
+
 			const locals = services.instance?.locals?.(Framework, this) || {}
 			localsMap.set(this, locals)
 			handleArray(Framework as any, services.instance?.services, this, this, locals)
+			for(const collection of services.collections || [])
+				handleArray(Framework as any, collection.instance?.services, this, this, locals)
 		}
 	} as any as ServiceFramework<S>
 
 	Framework.getLocals = instance => localsMap.get(instance)
 	Framework.locals = services.static?.locals || {}
 	handleArray(Framework as any, services.static?.services, Framework)
+	for (const collection of services.collections || [])
+		handleArray(Framework as any, collection.static?.services, Framework)
+	
 	Object.defineProperty(Framework, 'name', { value: services.entity.name })
 
 	return Framework

--- a/src/create-services.ts
+++ b/src/create-services.ts
@@ -1,7 +1,9 @@
 import { createServiceFramework } from './create-service'
 import { Service, ServiceFramework } from './types'
 
-export function createServicesFramework<const S extends Record<string, Service<unknown>>>(
+export function createServicesFramework<
+	const S extends Record<string, Service<unknown>>
+>(
 	services: S
 ) {
 	const result = {} as Record<string, unknown>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, beforeAll, expect } from 'vitest'
-import { ClassConstructor, Collection, InstanceServiceFunction, Service, StaticServiceFunction, createServicesFramework } from '.'
+import {
+	ClassConstructor,
+	Collection,
+	InstanceServiceFunction,
+	Service,
+	StaticServiceFunction,
+	createServicesFramework
+} from '.'
 
 
 class User {
@@ -13,7 +20,10 @@ class User {
 
 function createFramework() {
 	// * --- Seperate files --- *
-	const nameToUpper = (<T extends { name: string }>(service: ClassConstructor<T>, instance: T) => ({
+	const nameToUpper = (<T extends { name: string }>(
+		service: ClassConstructor<T>,
+		instance: T
+	) => ({
 		
 		nameToUpper(newName?: string) {
 			instance.name = (newName || instance.name).toUpperCase()
@@ -104,7 +114,11 @@ function createFramework() {
 			]
 		},
 		instance: {
-			locals: (service, instance) => ({ service, instance, now: (Date.now() / 1000).toFixed(0) }),
+			locals: (service, instance) => ({
+				service,
+				instance,
+				now: (Date.now() / 1000).toFixed(0)
+			}),
 			services: [
 				getName<User>,
 				getInstance<User>,
@@ -135,8 +149,6 @@ function createFramework() {
 describe('service-framework', () => {
 	let framework: ReturnType<typeof createFramework>
 
-	
-	
 	beforeAll(() => {
 		framework = createFramework()
 	})
@@ -183,7 +195,10 @@ describe('service-framework', () => {
 		const locals = user.getLocal()
 		const local = framework.User.getLocals(user)
 
-		expect(framework.User.locals).to.deep.equal({ collection: 'users', test: 'Testing static locals' })
+		expect(framework.User.locals).to.deep.equal({
+			collection: 'users',
+			test: 'Testing static locals'
+		})
 		expect(local).to.deep.equal(locals)
 		expect(locals).to.deep.equal({
 			service: framework.User,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export type { Service, Class, ClassConstructor, StaticServiceFunction, InstanceServiceFunction } from './types'
+export type { ClassOf, Service, Class, ClassConstructor, StaticServiceFunction, InstanceServiceFunction, Collection } from './types'
 export { createServicesFramework } from './create-services'
 export { createServiceFramework } from './create-service'

--- a/src/type.testing.ts
+++ b/src/type.testing.ts
@@ -42,7 +42,10 @@ const availableBurgers = (<T extends ClassOf<any>>(Entity: ClassConstructor<T>) 
 
 })) satisfies StaticServiceFunction
 
-const mergeDocument = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, instance: Class<C>) => ({
+const mergeDocument = (<C extends ClassOf<any>>(
+	entity: ClassConstructor<C>,
+	instance: Class<C>
+) => ({
 	
 	async mergeDocument(merge: Partial<C>) {
 		// ...
@@ -50,7 +53,10 @@ const mergeDocument = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, ins
 
 })) satisfies InstanceServiceFunction
 
-const deleteDocument = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, instance: Class<C>) => ({
+const deleteDocument = (<C extends ClassOf<any>>(
+	entity: ClassConstructor<C>,
+	instance: Class<C>
+) => ({
 	
 	async deleteDocument(merge: Partial<C>) {
 		// ...
@@ -58,7 +64,10 @@ const deleteDocument = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, in
 
 })) satisfies InstanceServiceFunction
 
-const consumePizza = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, instance: Class<C>) => ({
+const consumePizza = (<C extends ClassOf<any>>(
+	entity: ClassConstructor<C>,
+	instance: Class<C>
+) => ({
 
 	async consumePizza(merge: Partial<C>) {
 		// ...
@@ -66,7 +75,10 @@ const consumePizza = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, inst
 
 })) satisfies InstanceServiceFunction
 
-const consumeBurger = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, instance: Class<C>) => ({
+const consumeBurger = (<C extends ClassOf<any>>(
+	entity: ClassConstructor<C>,
+	instance: Class<C>
+) => ({
 
 	async consumeBurger(merge: Partial<C>) {
 		// ...

--- a/src/type.testing.ts
+++ b/src/type.testing.ts
@@ -1,5 +1,5 @@
 
-import { createServicesFramework, Class, ClassConstructor, StaticServiceFunction, InstanceServiceFunction, Service } from '.'
+import { ClassOf, createServicesFramework, Class, ClassConstructor, StaticServiceFunction, InstanceServiceFunction, Service } from '.'
 
 class User {
 	id: number
@@ -10,7 +10,7 @@ class User {
 	}
 }
 
-const getFromDatabase = (<T extends Class<any>>(Entity: ClassConstructor<T>) => ({
+const getFromDatabase = (<T extends ClassOf<any>>(Entity: ClassConstructor<T>) => ({
 	
 	async getFromDatabase(filter: Partial<T>) {
 		return {} as T
@@ -18,7 +18,7 @@ const getFromDatabase = (<T extends Class<any>>(Entity: ClassConstructor<T>) => 
 
 })) satisfies StaticServiceFunction
 
-const getAll = (<T extends Class<any>>(Entity: ClassConstructor<T>) => ({
+const getAll = (<T extends ClassOf<any>>(Entity: ClassConstructor<T>) => ({
 
 	async getAll(filter: Partial<T>) {
 		return {} as T
@@ -26,7 +26,23 @@ const getAll = (<T extends Class<any>>(Entity: ClassConstructor<T>) => ({
 
 })) satisfies StaticServiceFunction
 
-const mergeDocument = (<C extends Class<any>>(entity: ClassConstructor<C>, instance: C) => ({
+const availablePizzas = (<T extends ClassOf<any>>(Entity: ClassConstructor<T>) => ({
+
+	async availablePizzas(filter: Partial<T>) {
+		return {} as T
+	}
+
+})) satisfies StaticServiceFunction
+
+const availableBurgers = (<T extends ClassOf<any>>(Entity: ClassConstructor<T>) => ({
+
+	async availableBurgers(filter: Partial<T>) {
+		return {} as T
+	}
+
+})) satisfies StaticServiceFunction
+
+const mergeDocument = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, instance: Class<C>) => ({
 	
 	async mergeDocument(merge: Partial<C>) {
 		// ...
@@ -34,7 +50,7 @@ const mergeDocument = (<C extends Class<any>>(entity: ClassConstructor<C>, insta
 
 })) satisfies InstanceServiceFunction
 
-const deleteDocument = (<C extends Class<any>>(entity: ClassConstructor<C>, instance: C) => ({
+const deleteDocument = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, instance: Class<C>) => ({
 	
 	async deleteDocument(merge: Partial<C>) {
 		// ...
@@ -42,6 +58,21 @@ const deleteDocument = (<C extends Class<any>>(entity: ClassConstructor<C>, inst
 
 })) satisfies InstanceServiceFunction
 
+const consumePizza = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, instance: Class<C>) => ({
+
+	async consumePizza(merge: Partial<C>) {
+		// ...
+	}
+
+})) satisfies InstanceServiceFunction
+
+const consumeBurger = (<C extends ClassOf<any>>(entity: ClassConstructor<C>, instance: Class<C>) => ({
+
+	async consumeBurger(merge: Partial<C>) {
+		// ...
+	}
+
+})) satisfies InstanceServiceFunction
 
 const userService = {
 
@@ -49,7 +80,7 @@ const userService = {
 
 	static: {
 		locals: {
-			collection: 'users'
+			table: 'users'
 		},
 		services: [
 			getFromDatabase<User>,
@@ -79,7 +110,23 @@ const userService = {
 				}
 			}
 		]
-	}
+	},
+	collections: [
+		{
+			static: {
+				services: [
+					availablePizzas<User>,
+					availableBurgers<User>,
+				]
+			},
+			instance: {
+				services: [
+					consumePizza<User>,
+					consumeBurger<User>
+				]
+			}
+		}
+	]
 } satisfies Service<User>
 
 
@@ -98,6 +145,12 @@ entitites.User.nested.getFromDatabase({ id: 1 })
 entitites.User.nested.getAll({ id: 1 })
 //               ^?
 
+entitites.User.availableBurgers({ id: 1 })
+//               ^?
+
+entitites.User.availablePizzas({ id: 1 })
+//               ^?
+
 const user = new entitites.User({ id: 1, name: 'Carl' })
 
 user.mergeDocument({ name: 'Bob' })
@@ -109,3 +162,9 @@ user.nested.functions.mergeDocument({ name: 'Bob' })
 //             ^?
 user.nested.functions.deleteDocument({ name: 'Bob' })
 //             ^?
+
+user.consumeBurger({})
+//       ^?
+
+user.consumePizza({})
+//       ^?

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,8 +34,11 @@ export interface Service<E extends ClassConstructor<any> | Class<any>> {
 
 // * --- Utility --- * //
 
-export type Class<T> = T
+
+export type Class<T extends ClassConstructor<any> | any> = T extends ClassConstructor<infer K> ? K : T
 export type ClassConstructor<T = any, TArgs extends Array<any> = any> = new (...args: TArgs) => T
+export type ClassOf<T extends ClassConstructor<any> | any> = T extends ClassConstructor<any> ? T : ClassConstructor<T>
+
 type AnyRecord = Record<any, any>
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
 type IntersectArray<U extends Array<any>> = UnionToIntersection<U[number]>

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type Class<T extends ClassConstructor<any> | any> = T extends ClassConstr
 export type ClassConstructor<T = any, TArgs extends Array<any> = any> = new (...args: TArgs) => T
 export type ClassOf<T extends ClassConstructor<any> | any> = T extends ClassConstructor<any> ? T : ClassConstructor<T>
 
-type AnyRecord = Record<any, any>
+export type AnyRecord = Record<any, any>
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
 type IntersectArray<U extends Array<any>> = UnionToIntersection<U[number]>
 type IntersectFunctionArray<U extends Array<(...args: any) => any>> = UnionToIntersection<Returned<U[number]>>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
-export type InferConstructor<T extends ClassConstructor<any>> = T extends new (...args: any) => infer K ? K : never
-export type InferConstructorArgs<T extends ClassConstructor<any>> = T extends new (...args: infer K) => any ? K : never
+export type InferConstructor<T extends ClassConstructor<any>> =
+	T extends new (...args: any) => infer K ? K : never
+
+export type InferConstructorArgs<T extends ClassConstructor<any>> =
+	T extends new (...args: infer K) => any ? K : never
 
 export type StaticServiceFunction<E = any> = <C extends E>(
 	service: ClassConstructor<C>
@@ -13,7 +16,8 @@ export type InstanceServiceFunction<E = any> = <C extends E>(
 ) => Record<string, (...args: any) => any>
 
 type Recurse<O> = Record<string, O> | Readonly<Array<Record<string, O>> | O> | O
-type RecursiveObject<O> = Readonly<Array<Recurse<O | Recurse<O | Recurse<O | Recurse<O | Recurse<O>>>>>>>
+type RecursiveObject<O> =
+	Readonly<Array<Recurse<O | Recurse<O | Recurse<O | Recurse<O | Recurse<O>>>>>>>
 
 export type StaticServicesOpts = RecursiveObject<StaticServiceFunction>
 export type InstanceServicesOpts = RecursiveObject<InstanceServiceFunction>
@@ -37,26 +41,41 @@ export interface Service<E extends ClassOf<any>> {
 
 
 // * --- Utility --- * //
-export type Class<T extends ClassConstructor<any> | any> = T extends ClassConstructor<infer K> ? K : T
-export type ClassConstructor<T = any, TArgs extends Array<any> = any> = new (...args: TArgs) => T
-export type ClassOf<T extends ClassConstructor<any> | any> = T extends ClassConstructor<any> ? T : ClassConstructor<T>
+export type Class<T extends ClassConstructor<any> | any> =
+	T extends ClassConstructor<infer K> ? K : T
+
+export type ClassConstructor<T = any, TArgs extends Array<any> = any> =
+	new (...args: TArgs) => T
+
+export type ClassOf<T extends ClassConstructor<any> | any> =
+	T extends ClassConstructor<any> ? T : ClassConstructor<T>
 
 export type AnyRecord = Record<any, any>
-type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+
+type UnionToIntersection<U> =
+	(U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+
 type IntersectArray<U extends Array<any>> = UnionToIntersection<U[number]>
-type IntersectFunctionArray<U extends Array<(...args: any) => any>> = UnionToIntersection<Returned<U[number]>>
+
+type IntersectFunctionArray<U extends Array<(...args: any) => any>> =
+	UnionToIntersection<Returned<U[number]>>
+
 export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & NonNullable<unknown>
 
 
 // * --- Handle services --- * //
-type HandleServices<S> = S extends Array<any> ? Simplify<HandleArray<S>> : Simplify<Nested<S>>
+type HandleServices<S> =
+	S extends Array<any> ? Simplify<HandleArray<S>> : Simplify<Nested<S>>
+
 type Returned<K> = K extends (...args: any) => any ? ReturnType<K> : never
 type Nested<K> = {
 	[Key in keyof K]:
 	K[Key] extends (...args: any) => any ? ReturnType<K[Key]>
-	: K[Key] extends Array<any> ? Simplify<HandleArray<K[Key]>> : Simplify<Nested<K[Key]>>
+	: K[Key] extends Array<any> ? Simplify<HandleArray<K[Key]>>
+	: Simplify<Nested<K[Key]>>
 }
-type HandleArray<K extends Array<any>> = IntersectFunctionArray<K> & Simplify<Nested<IntersectArray<K>>>
+type HandleArray<K extends Array<any>> =
+	IntersectFunctionArray<K> & Simplify<Nested<IntersectArray<K>>>
 
 
 // * --- Handle collections --- * //

--- a/src/utils/merge-deep.test.ts
+++ b/src/utils/merge-deep.test.ts
@@ -1,0 +1,52 @@
+import {
+	describe,
+	it,
+	expect
+} from 'vitest'
+import { mergeDeep } from './merge-deep'
+
+describe('utils/merge-deep', () => {
+	it('should merge objects', () => {
+		const o1 = {
+			a: 1,
+			b: 1,
+			c: {
+				d: 1,
+				e: 1,
+				f: {
+					g: 1,
+					h: 1
+				}
+			}
+		}
+		const o2 = {
+			b: 2,
+			c: {
+				d: 2,
+				e: 2
+			}
+		}
+		const o3 = {
+			a: 3,
+			c: {
+				f: {
+					g: 3
+				}
+			}
+		}
+
+		const result = {
+			a: 3,
+			b: 2,
+			c: {
+				d: 2,
+				e: 2,
+				f: {
+					g: 3,
+					h: 1
+				}
+			}
+		}
+		expect(mergeDeep(o1, undefined, o2, undefined, o3)).toEqual(result)
+	})
+})

--- a/src/utils/merge-deep.ts
+++ b/src/utils/merge-deep.ts
@@ -1,0 +1,40 @@
+// Credit: https://stackoverflow.com/a/34749873
+
+import { AnyRecord } from '../types'
+
+export function isObject(item: AnyRecord) {
+	return (item && typeof item === 'object' && !Array.isArray(item))
+}
+
+/**
+ * Deep merge two objects.
+*/
+export function mergeDeep(target: AnyRecord, ...sources: (AnyRecord | undefined)[]) {
+	if (!sources || sources.length <= 0)
+		return target
+	
+	let source = sources.shift()
+	while (source === undefined) {
+
+		if (sources.length <= 0)
+			return target
+		source = sources.shift()
+
+	}
+
+	if (isObject(target) && isObject(source)) {
+		for (const key in source) {
+
+			if (isObject(source[key])) {
+				if (!target[key]) Object.assign(target, { [key]: {} })
+				mergeDeep(target[key], source[key])
+			}
+			else {
+				Object.assign(target, { [key]: source[key] })
+			}
+
+		}
+	}
+
+	return mergeDeep(target, ...sources)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"target": "ES2020",
 		"useDefineForClassFields": true,
 		"module": "ESNext",
-		"lib": ["ES2020"],
+		"lib": ["ES2020",  "DOM"],
 		"skipLibCheck": true,
 
 		/* Bundler mode */


### PR DESCRIPTION
Service collections allows you to combine multiple services into a collection. This includes locals.

```ts
// .../services/collection.my-collection.ts
export default (<T>() => ({

    static: {
        locals: {...},
        services: [...]
    },
    instance: {
        locals: (Service, instance) => ({ ... }),
        services: [...]
    }

}) satisfies Collection<T>)

// .../services/index.ts
export default createServicesFramework({
    
    User: {
        entity: User,
        instance: {...},
        static: {...},
        collections: [
            myCollection<User>(),
            ...
        ]
    }

})
```

Now you don't have to re-apply the same services over and over — but just combine 
them into a collection.
